### PR TITLE
Restore the phar stream wrapper only when needed

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -3,7 +3,10 @@
 $rootPath = __DIR__ . '/../../../';
 
 require_once $rootPath . 'app/bootstrap.php';
-stream_wrapper_restore('phar');
+
+if (!in_array('phar', stream_get_wrappers()) && !empty(Phar::running())) {
+    stream_wrapper_restore('phar');
+}
 
 $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
 $bootstrap->getObjectManager();


### PR DESCRIPTION
Stops a PHP notice saying "PHP Notice:  stream_wrapper_restore(): phar:// was never changed, nothing to restore", and avoids unnecessarily restoring it when using phpstan/phpstan