### PR TITLE
Fix issue when phar extension is not restored when using phar distribution of phpstan

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,7 +4,7 @@ $rootPath = __DIR__ . '/../../../';
 
 require_once $rootPath . 'app/bootstrap.php';
 
-if (!in_array('phar', stream_get_wrappers()) && !empty(Phar::running())) {
+if (!in_array('phar', stream_get_wrappers()) && extension_loaded('phar')) {
     stream_wrapper_restore('phar');
 }
 


### PR DESCRIPTION
before:
```
build@94dfa729de34:/app$ php phpstan.phar analyse ./src
Note: Using configuration file /app/phpstan.neon.
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(phar:///app/phpstan.phar/vendor/composer/../../src/File/FileFinder.php): failed to open stream: No such file or directory in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Failed opening 'phar:///app/phpstan.phar/vendor/composer/../../src/File/FileFinder.php' for inclusion (include_path='/app/generated/code:/app/generated/code:/app/vendor/magento/zendframework1/library:.:/usr/share/php') in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(phar:///app/phpstan.phar/vendor/composer/../../src/File/FileExcluder.php): failed to open stream: No such file or directory in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Failed opening 'phar:///app/phpstan.phar/vendor/composer/../../src/File/FileExcluder.php' for inclusion (include_path='/app/generated/code:/app/generated/code:/app/vendor/magento/zendframework1/library:.:/usr/share/php') in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(phar:///app/phpstan.phar/vendor/composer/../../src/File/FileFinderResult.php): failed to open stream: No such file or directory in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Failed opening 'phar:///app/phpstan.phar/vendor/composer/../../src/File/FileFinderResult.php' for inclusion (include_path='/app/generated/code:/app/generated/code:/app/vendor/magento/zendframework1/library:.:/usr/share/php') in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(phar:///app/phpstan.phar/vendor/composer/../../src/Command/InceptionResult.php): failed to open stream: No such file or directory in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Warning:  include(): Failed opening 'phar:///app/phpstan.phar/vendor/composer/../../src/Command/InceptionResult.php' for inclusion (include_path='/app/generated/code:/app/generated/code:/app/vendor/magento/zendframework1/library:.:/usr/share/php') in /app/vendor/composer/ClassLoader.php on line 444
[22-Nov-2019 14:53:25 UTC] PHP Fatal error:  Uncaught TypeError: Argument 3 passed to PHPStan\Command\InceptionResult::__construct() must be an instance of Symfony\Component\Console\Style\OutputStyle, instance of PHPStan\Command\ErrorsConsoleStyle given, called in phar:///app/phpstan.phar/src/Command/CommandHelper.php on line 251 and defined in /app/vendor/phpstan/phpstan/src/Command/InceptionResult.php:46
Stack trace:
#0 phar:///app/phpstan.phar/src/Command/CommandHelper.php(251): PHPStan\Command\InceptionResult->__construct(Array, false, Object(PHPStan\Command\ErrorsConsoleStyle), Object(_HumbugBoxbfaeed0746fa\Symfony\Component\Console\Output\StreamOutput), Object(Container_a89de0b3e2), false, '/tmp/phpstan/.m...', '/app/phpstan.ne...')
#1 phar:///app/phpstan.phar/src/Command/AnalyseCommand.php(52): PHPStan\Command\CommandHelper::begin(Object(_HumbugBoxbfaeed0746fa\Symfony\Component\Console\Input\ArgvInput), Object(_HumbugBoxbfaeed0746fa\Symfony\Component\Console\Output\ConsoleOutput), Array, NULL, NULL, NULL, '/app/phpstan.ne...', 'max', false)
#2 ph in /app/vendor/phpstan/phpstan/src/Command/InceptionResult.php on line 46
```

after:
```
build@94dfa729de34:/app$ php phpstan.phar analyse ./src
Note: Using configuration file /app/phpstan.neon.
  591/2324 [▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░]  25%^C
```